### PR TITLE
Updated version of the aem-groovy-extension-bundle to 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -470,7 +470,7 @@
             <dependency>
                 <groupId>com.citytechinc.aem.groovy.extension</groupId>
                 <artifactId>aem-groovy-extension-bundle</artifactId>
-                <version>1.0.1</version>
+                <version>1.1.0</version>
             </dependency>
             <dependency>
                 <groupId>org.spockframework</groupId>


### PR DESCRIPTION
Updated version of the aem-groovy-extension-bundle to 1.1.0 to resolve bundle dependency issues.
