### PR TITLE
Added ability to set protocol on both internal links (with host) and external links

### DIFF
--- a/aem-library-api/src/main/java/com/icfolson/aem/library/api/link/builders/LinkBuilder.java
+++ b/aem-library-api/src/main/java/com/icfolson/aem/library/api/link/builders/LinkBuilder.java
@@ -138,7 +138,8 @@ public interface LinkBuilder {
     LinkBuilder setHost(String host);
 
     /**
-     * Set the protocol.  If set, the protocol will override the default value of "http" (or "https" if secure=true).
+     * Set the protocol (e.g. "ftp://" or "tel:").
+     * If set, the protocol will override the default value of "http://" (or "https://" if secure=true).
      *
      * @param protocol protocol
      * @return builder

--- a/aem-library-core/src/main/groovy/com/icfolson/aem/library/core/link/builders/impl/DefaultLinkBuilder.groovy
+++ b/aem-library-core/src/main/groovy/com/icfolson/aem/library/core/link/builders/impl/DefaultLinkBuilder.groovy
@@ -265,14 +265,18 @@ final class DefaultLinkBuilder implements LinkBuilder {
                 builder.append(protocol)
             } else {
                 builder.append(secure ? "https" : "http")
+                builder.append("://")
             }
-
-            builder.append("://")
             builder.append(host)
 
             if (port > 0) {
                 builder.append(':')
                 builder.append(port)
+            }
+        }
+        if (isExternal) {
+            if (protocol && !path.startsWith(protocol)) {
+                builder.append(protocol)
             }
         }
 

--- a/aem-library-core/src/test/groovy/com/icfolson/aem/library/core/link/builders/impl/DefaultLinkBuilderSpec.groovy
+++ b/aem-library-core/src/test/groovy/com/icfolson/aem/library/core/link/builders/impl/DefaultLinkBuilderSpec.groovy
@@ -194,8 +194,8 @@ class DefaultLinkBuilderSpec extends AemLibrarySpec {
         "json"    | ""        | null     | "localhost" | 0    | false  | "http://localhost/content.json"
         null      | ""        | null     | "localhost" | 4502 | false  | "http://localhost:4502/content.html"
         null      | ""        | null     | "localhost" | 0    | true   | "https://localhost/content.html"
-        null      | ""        | "ftp"    | "localhost" | 0    | false  | "ftp://localhost/content.html"
-        null      | ""        | "ftp"    | "localhost" | 0    | true   | "ftp://localhost/content.html"
+        null      | ""        | "ftp://" | "localhost" | 0    | false  | "ftp://localhost/content.html"
+        null      | ""        | "ftp://" | "localhost" | 0    | true   | "ftp://localhost/content.html"
     }
 
     def "build link and set external"() {
@@ -228,6 +228,42 @@ class DefaultLinkBuilderSpec extends AemLibrarySpec {
         "/content"              | ["a"]      | "/content.a.html"
         "/content"              | ["a", "b"] | "/content.a.b.html"
         "http://www.reddit.com" | ["a", "b"] | "http://www.reddit.com"
+    }
+
+    def "build link for path with protocol"() {
+        setup:
+        def link = LinkBuilderFactory.forPath(path).setProtocol(protocol).build()
+
+        expect:
+        link.href == href
+
+        where:
+        path                    | protocol     | href
+        "/content"              | "http://"    | "/content.html"
+        "+48957228989"          | "tel:"       | "tel:+48957228989"
+        "http://www.reddit.com" | ""           | "http://www.reddit.com"
+        "http://www.reddit.com" | "http://"    | "http://www.reddit.com"
+        "www.reddit.com"        | "https://"   | "https://www.reddit.com"
+        "https://reddit.com"    | "ftp:"       | "ftp:https://reddit.com"
+        "someone@domain.com"    | "mailto:"    | "mailto:someone@domain.com"
+    }
+
+    def "build link for link and set protocol"() {
+        setup:
+        def link = LinkBuilderFactory.forPath(path).build()
+
+        expect:
+        LinkBuilderFactory.forLink(link).setProtocol(protocol).build().href == href
+
+        where:
+        path                    | protocol     | href
+        "/content"              | "http://"    | "/content.html"
+        "+48957228989"          | "tel:"       | "tel:+48957228989"
+        "http://www.reddit.com" | ""           | "http://www.reddit.com"
+        "http://www.reddit.com" | "http://"    | "http://www.reddit.com"
+        "www.reddit.com"        | "https://"   | "https://www.reddit.com"
+        "https://reddit.com"    | "ftp:"       | "ftp:https://reddit.com"
+        "someone@domain.com"    | "mailto:"    | "mailto:someone@domain.com"
     }
 
     def "build link for path with parameters"() {

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.icfolson.aem</groupId>
         <artifactId>aem-parent-uber-jar</artifactId>
-        <version>7.0.1-SNAPSHOT</version>
+        <version>7.0.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Updated how the protocol is set.
I expanded it to external links as well. This would be useful if you have a Link (e.g when using the Link Injector) but later want to add a protocol.
All protocols are now supported : https://, http://, tel:, mailto: etc. 
If the path (for external links) already contains protocol, and one is set explicitly, it will result is multiple protocols if they are different.